### PR TITLE
chore: remove shared workspace

### DIFF
--- a/NPM_COMMANDS.md
+++ b/NPM_COMMANDS.md
@@ -8,18 +8,16 @@ This is a monorepo with the following structure:
 - **Root**: Main project configuration and workspace management
 - **api/**: Express.js backend server
 - **frontend/**: Next.js frontend application
-- **shared/**: Shared utilities and components
 
 ## Installation Commands
 
 ### `npm install`
-Installs all dependencies for the root project and all workspaces (api, frontend, shared).
+Installs all dependencies for the root project and all workspaces (api, frontend).
 
 **What it does:**
 - Installs root dependencies (concurrently)
 - Installs dependencies for the api workspace
 - Installs dependencies for the frontend workspace
-- Installs dependencies for the shared workspace (if any)
 
 **Usage:**
 ```bash
@@ -143,7 +141,6 @@ Removes all node_modules directories from the project.
 - Deletes node_modules from the root directory
 - Deletes node_modules from the api directory
 - Deletes node_modules from the frontend directory
-- Deletes node_modules from the shared directory
 
 **Usage:**
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "MIT",
       "workspaces": [
         "api",
-        "frontend",
-        "shared"
+        "frontend"
       ],
       "devDependencies": {
         "concurrently": "^8.2.2"

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "description": "A web app for helping gamers get achievements/trophies for their games",
   "workspaces": [
     "api",
-    "frontend",
-    "shared"
+    "frontend"
   ],
   "scripts": {
     "dev": "concurrently \"npm run dev:api\" \"npm run dev:frontend\"",
@@ -17,7 +16,7 @@
     "start:api": "npm run start --workspace=api",
     "start:frontend": "npm run start --workspace=frontend",
     "install:all": "npm install && npm install --workspace=api && npm install --workspace=frontend",
-    "clean": "rm -rf node_modules && rm -rf api/node_modules && rm -rf frontend/node_modules && rm -rf shared/node_modules",
+    "clean": "rm -rf node_modules && rm -rf api/node_modules && rm -rf frontend/node_modules",
     "lint": "npm run lint --workspace=frontend"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- remove unused `shared` workspace and associated clean script
- update docs to reflect remaining `api` and `frontend` workspaces

## Testing
- `npm run lint` *(fails: Lifecycle script `lint` failed with error: command sh -c next lint)*

------
https://chatgpt.com/codex/tasks/task_e_68abf78875b0832687ac7fb691d66464