### PR TITLE
Add backend tests and documentation

### DIFF
--- a/NPM_COMMANDS.md
+++ b/NPM_COMMANDS.md
@@ -297,3 +297,17 @@ If you get "port already in use" errors:
 - Hot-reload is enabled for both development servers
 - The frontend must be built before running in production mode
 - All commands should be run from the project root directory
+
+## Testing Commands
+
+### `npm test`
+Runs backend unit and integration tests.
+
+**What it does:**
+- Executes Jest tests in the `api` workspace
+- Verifies authentication endpoints, guide generation, middleware, and CORS behavior
+
+**Usage:**
+```bash
+npm test
+```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # project_achievr
 A web app for helping gamers get achievements/trophies for their games
+
+## Testing
+
+Run backend unit and integration tests with:
+
+```bash
+npm test
+```
+
+Tests cover authentication endpoints, guide generation, middleware, and CORS behavior.

--- a/api/index.js
+++ b/api/index.js
@@ -17,9 +17,24 @@ app.get('/auth/xbox', (req, res) => {
 });
 
 app.post('/generate-guide', (req, res) => {
-  const { game } = req.body;
+  const { game } = req.body || {};
+  if (typeof game !== 'string' || game.trim() === '') {
+    return res.status(400).json({ error: 'Invalid game' });
+  }
   res.json({ message: `AI guide generation scaffold for ${game}` });
 });
 
+app.use((err, req, res, next) => {
+  if (err instanceof SyntaxError && 'body' in err) {
+    return res.status(400).json({ error: 'Invalid JSON' });
+  }
+  console.error(err);
+  res.status(500).json({ error: 'Internal Server Error' });
+});
+
 const PORT = process.env.PORT || 4000;
-app.listen(PORT, () => console.log(`API running on port ${PORT}`));
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(PORT, () => console.log(`API running on port ${PORT}`));
+}
+
+module.exports = app;

--- a/api/package.json
+++ b/api/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "dev": "nodemon index.js",
-    "start": "node index.js"
+    "start": "node index.js",
+    "test": "jest"
   },
   "dependencies": {
     "express": "4.19.2",
@@ -15,6 +16,8 @@
     "openai": "4.54.0"
   },
   "devDependencies": {
-    "nodemon": "3.1.0"
+    "nodemon": "3.1.0",
+    "jest": "29.7.0",
+    "supertest": "6.3.4"
   }
 }

--- a/api/tests/auth.test.js
+++ b/api/tests/auth.test.js
@@ -1,0 +1,42 @@
+const request = require('supertest');
+const app = require('../index');
+
+describe('/auth endpoints', () => {
+  describe('/auth/psn', () => {
+    test('returns placeholder message for valid GET', async () => {
+      const res = await request(app).get('/auth/psn');
+      expect(res.status).toBe(200);
+      expect(res.text).toBe('PSN authentication endpoint placeholder');
+    });
+
+    test('returns 404 for unsupported method', async () => {
+      const res = await request(app).post('/auth/psn');
+      expect(res.status).toBe(404);
+    });
+
+    test('handles query parameters gracefully', async () => {
+      const res = await request(app).get('/auth/psn').query({ foo: 'bar' });
+      expect(res.status).toBe(200);
+      expect(res.text).toBe('PSN authentication endpoint placeholder');
+    });
+  });
+
+  describe('/auth/xbox', () => {
+    test('returns placeholder message for valid GET', async () => {
+      const res = await request(app).get('/auth/xbox');
+      expect(res.status).toBe(200);
+      expect(res.text).toBe('Xbox authentication endpoint placeholder');
+    });
+
+    test('returns 404 for unsupported method', async () => {
+      const res = await request(app).post('/auth/xbox');
+      expect(res.status).toBe(404);
+    });
+
+    test('handles query parameters gracefully', async () => {
+      const res = await request(app).get('/auth/xbox').query({ foo: 'bar' });
+      expect(res.status).toBe(200);
+      expect(res.text).toBe('Xbox authentication endpoint placeholder');
+    });
+  });
+});

--- a/api/tests/generateGuide.test.js
+++ b/api/tests/generateGuide.test.js
@@ -1,0 +1,22 @@
+const request = require('supertest');
+const app = require('../index');
+
+describe('/generate-guide', () => {
+  test('generates guide when game is provided', async () => {
+    const res = await request(app).post('/generate-guide').send({ game: 'Halo' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ message: 'AI guide generation scaffold for Halo' });
+  });
+
+  test('returns 400 when game is missing', async () => {
+    const res = await request(app).post('/generate-guide').send({});
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'Invalid game' });
+  });
+
+  test('returns 400 when game is not a string', async () => {
+    const res = await request(app).post('/generate-guide').send({ game: 42 });
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'Invalid game' });
+  });
+});

--- a/api/tests/integration.test.js
+++ b/api/tests/integration.test.js
@@ -1,0 +1,23 @@
+const request = require('supertest');
+const app = require('../index');
+
+describe('integration tests', () => {
+  test('sets CORS headers', async () => {
+    const res = await request(app).get('/auth/psn');
+    expect(res.headers['access-control-allow-origin']).toBe('*');
+  });
+
+  test('handles invalid JSON body', async () => {
+    const res = await request(app)
+      .post('/generate-guide')
+      .set('Content-Type', 'application/json')
+      .send('{"game": "Halo"');
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'Invalid JSON' });
+  });
+
+  test('returns 404 for unknown routes', async () => {
+    const res = await request(app).get('/does-not-exist');
+    expect(res.status).toBe(404);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "start:frontend": "npm run start --workspace=frontend",
     "install:all": "npm install && npm install --workspace=api && npm install --workspace=frontend",
     "clean": "rm -rf node_modules && rm -rf api/node_modules && rm -rf frontend/node_modules && rm -rf shared/node_modules",
-    "lint": "npm run lint --workspace=frontend"
+    "lint": "npm run lint --workspace=frontend",
+    "test": "npm test --workspace=api"
   },
   "devDependencies": {
     "concurrently": "^8.2.2"


### PR DESCRIPTION
## Summary
- add request validation and error handling to Express API
- introduce Jest-based unit and integration tests for auth and guide endpoints
- document test workflow in README and NPM_COMMANDS

## Testing
- `npm install --workspace=api` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abf7842ee88326942984cbd731c066