### PR TITLE
docs: add setup guide and env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Root environment variables used by both API and frontend
+# Next.js automatically reads root `.env` files (`.env`, `.env.local`, etc.), so no separate frontend `.env` is needed.
+
+# Server port
+PORT=4000
+
+# OpenAI API key for AI-powered features
+OPENAI_API_KEY=your-openai-api-key
+
+# Frontend URL to reach the API
+NEXT_PUBLIC_API_URL=http://localhost:4000
+
+# Node environment
+NODE_ENV=development

--- a/NPM_COMMANDS.md
+++ b/NPM_COMMANDS.md
@@ -44,8 +44,8 @@ npm run install:all
 ### `npm run dev`
 **Main development command** - Starts both frontend and backend servers simultaneously in development mode.
 
-**What it does:**
-- Starts the Express.js API server (typically on port 3001)
+-**What it does:**
+- Starts the Express.js API server (typically on port 4000)
 - Starts the Next.js frontend server (typically on port 3000)
 - Both servers run with hot-reload enabled
 
@@ -251,11 +251,11 @@ If the keyboard shortcut doesn't work or you need to stop a service from a diffe
 ```bash
 # Find processes using specific ports
 lsof -ti:3000  # Find process using port 3000 (frontend)
-lsof -ti:3001  # Find process using port 3001 (backend)
+lsof -ti:4000  # Find process using port 4000 (backend)
 
 # Kill the process
 kill -9 $(lsof -ti:3000)  # Kill process on port 3000
-kill -9 $(lsof -ti:3001)  # Kill process on port 3001
+kill -9 $(lsof -ti:4000)  # Kill process on port 4000
 ```
 
 **Method 3: Kill All Node Processes (Use with caution)**
@@ -269,7 +269,7 @@ killall node
 ### Common Ports Used by This Project
 
 - **Port 3000**: Next.js frontend development server
-- **Port 3001**: Express.js backend API server
+- **Port 4000**: Express.js backend API server
 
 ### Troubleshooting Port Conflicts
 
@@ -278,7 +278,7 @@ If you get "port already in use" errors:
 1. **Check what's using the port:**
    ```bash
    lsof -i:3000  # Check port 3000
-   lsof -i:3001  # Check port 3001
+   lsof -i:4000  # Check port 4000
    ```
 
 2. **Kill the conflicting process:**

--- a/README.md
+++ b/README.md
@@ -1,2 +1,85 @@
 # project_achievr
-A web app for helping gamers get achievements/trophies for their games
+
+A web app for helping gamers get achievements and trophies for their games.
+
+## Architecture
+
+The repository is a monorepo managed with npm workspaces:
+
+- **api/** – Express API server that exposes authentication and guide-generation endpoints.
+- **frontend/** – Next.js frontend for the user interface.
+- **shared/** – (future) shared utilities and components.
+
+The API communicates with external services such as OpenAI and gaming networks, and the frontend talks to the API over HTTP.
+
+> See `NPM_COMMANDS.md` for a full list of available npm scripts.
+
+## Prerequisites
+
+- Node.js 20+
+- npm 9+
+
+## Environment Variables
+
+Create a root `.env` file based on `.env.example` with the following variables. Next.js automatically loads root `.env` files (e.g. `.env.local`, `.env.development`, `.env.production`), so a separate `frontend/.env` is unnecessary. Variables prefixed with `NEXT_PUBLIC_` are exposed to the frontend build:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `PORT` | Port for the Express API server | `4000` |
+| `OPENAI_API_KEY` | OpenAI key used for guide generation | _none_ |
+| `NEXT_PUBLIC_API_URL` | Base URL the frontend uses to access the API | `http://localhost:4000` |
+| `NODE_ENV` | Node environment (`development`, `production`, etc.) | `development` |
+
+## Development Setup
+
+1. Clone the repository and navigate to the project root.
+2. Copy `.env.example` to `.env` and supply values.
+3. Install dependencies:
+   ```bash
+   npm install
+   ```
+4. Start both servers with hot reload:
+   ```bash
+   npm run dev
+   ```
+   - Frontend: http://localhost:3000
+   - API: http://localhost:4000
+
+## Production Setup
+
+1. Ensure environment variables are configured.
+2. Install dependencies and build the frontend:
+   ```bash
+   npm install
+   npm run build
+   ```
+3. Start the servers:
+   ```bash
+   npm run start
+   ```
+
+## Testing and Linting
+
+- Run the linter:
+  ```bash
+  npm run lint
+  ```
+- Run the test suite (to be implemented):
+  ```bash
+  npm test
+  ```
+
+## Deployment
+
+1. Build the frontend (`npm run build`).
+2. Run `npm run start` in a production environment with proper environment variables.
+3. Serve over HTTPS and place behind a reverse proxy or container orchestration platform as needed.
+
+## Security and Data Handling
+
+- Secrets such as `OPENAI_API_KEY` are supplied via environment variables and never committed.
+- Validate and sanitize all incoming requests to protect against injection attacks.
+- Limit logs to non-sensitive information; prefer centralized logging with access controls.
+- Use HTTPS in production and enable CORS only for trusted origins.
+- Follow least-privilege principles when integrating with external services and store only necessary user data.
+


### PR DESCRIPTION
## Summary
- clarify command reference and environment variable usage
- align npm command guide with API port 4000
- document root `.env` handling for Next.js and default API port

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68abf785d2148326ae0565637a3651ca