### PR TITLE
Enable strict TypeScript in frontend

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -6,9 +6,8 @@
       "dom.iterable",
       "esnext"
     ],
-    "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
@@ -24,7 +23,9 @@
     ],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
   "include": [


### PR DESCRIPTION
## Summary
- enable strict type checking in frontend
- remove JavaScript support from frontend tsconfig

------
https://chatgpt.com/codex/tasks/task_e_68abf7864e4883268f46aa2b694209e7